### PR TITLE
Refactored to only re-render changed cards when a card is selected/deselected

### DIFF
--- a/HigherOrLower/src/App.jsx
+++ b/HigherOrLower/src/App.jsx
@@ -4,22 +4,25 @@ import Card from "./Card";
 
 const cardData = [];
 const activeCards = {};
-const initialCardStatus = {};
+const cards = {};
 ["spades", "hearts", "diamonds", "clubs"].forEach((suit) => {
   const suitArray = [];
   ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"].forEach((rank, rankIndex) => {
     const rankNumber = rankIndex + 2;
-    const cardId = `${rank}${suit}`;
+    const cardId = `${rank}${suit[0]}`;
     suitArray.push({
-      id: cardId,
-      suit: suit,
-      rank: rank,
-      rankNumber: rankNumber,
-      img: `/${rank}${suit[0]}.png`,
-      alt: `${rank} of ${suit}`,
+      id: cardId
     });
+    cards[cardId] = {
+        suit: suit,
+        rank: rank,
+        rankNumber: rankNumber,
+        img: `/${rank}${suit[0]}.png`,
+        alt: `${rank} of ${suit}`,
+        selected: false,
+        inactive: false
+      };
     activeCards.hasOwnProperty(rankNumber) ? (activeCards[rankNumber] += 1) : (activeCards[rankNumber] = 1);
-    initialCardStatus[cardId] = { selected: false, inactive: false };
   });
   cardData.push(suitArray);
 });
@@ -29,8 +32,6 @@ export default function App() {
   const [cardCounts, setCardCounts] = useState(activeCards);
   // re-calculated when new card is selected/deselected and contains higher/lower/equal count for selected card
   const [stats, setStats] = useState({});
-  // used to track selected and inactive status of each card
-  const [cardStatus, setCardStatus] = useState(initialCardStatus);
   // keeps the history of selected cards (last entry is removed when a card is de-selected)
   const [cardsSelected, setCardsSelected] = useState([]);
   // marker to control when the updateTotals useEffect function runs
@@ -121,20 +122,19 @@ export default function App() {
   // compile an array containing a Card component for each card in the card array
   function cardsInSuit(suit) {
     return suit.map(card => {
-      return <Card key={`${card.rank}${card.suit}`} 
-                   cardData={card} 
-                   cardStatus={cardStatus[`${card.rank}${card.suit}`]} 
+      return <Card key={`${card.id}`} 
+                   cardData={cards[card.id]} 
                    selectCard={selectCard} 
                    deselectCard={deselectCard} />;      
     })
   }
 
   // compose cards array with outer cards-container and inner suit-container (for grid/flexbox styling)
-  const cards = (
+  const cardsArray = (
     <div className="cards-container">
       {cardData.map((suit) => {
         return (
-          <div key={suit[0].suit} className="suit-container">
+          <div key={suit[0].id} className="suit-container">
             {cardsInSuit(suit)};
           </div>
         );
@@ -145,7 +145,7 @@ export default function App() {
   return (
     <main className="outer-container">
       <h1>Higher or Lower</h1>
-      {cards}
+      {cardsArray}
       <Scores stats={stats} />
     </main>
   );

--- a/HigherOrLower/src/Card.jsx
+++ b/HigherOrLower/src/Card.jsx
@@ -11,8 +11,9 @@ export default function Card(props) {
     
   }
 
-  const inactive = props.cardStatus.inactive ? "fade" : "";
-  const selected = props.cardStatus.selected ? "highlight" : "";
+  const inactive = props.cardData.inactive ? "fade" : "";
+  const selected = props.cardData.selected ? "highlight" : "";
+  console.log("card rendered, props.cardData: ", props.cardData);
 
   return <img className={`card ${inactive} ${selected}`}
               src={props.cardData.img} 

--- a/HigherOrLower/src/Card.jsx
+++ b/HigherOrLower/src/Card.jsx
@@ -1,22 +1,16 @@
 import React from "react";
 
-export default function Card(props) {
+export default React.memo(function Card(props) {
   function handleClick(event) {
-    if (props.cardStatus.inactive) return;
-    if (!props.cardStatus.selected) {
-      props.selectCard(props.cardData);
-      return
-    }
-    props.deselectCard(props.cardData);
-    
+    if (props.inactive) return;
+    const action = props.selected ? { type: "deselect", id: props.id } : { type: "select", id: props.id };
+    props.cardClick(action);
   }
 
-  const inactive = props.cardData.inactive ? "fade" : "";
-  const selected = props.cardData.selected ? "highlight" : "";
-  console.log("card rendered, props.cardData: ", props.cardData);
+  const inactive = props.inactive ? "fade" : "";
+  const selected = props.selected ? "highlight" : "";
 
-  return <img className={`card ${inactive} ${selected}`}
-              src={props.cardData.img} 
-              alt={props.cardData.alt} 
-              onClick={handleClick} />;
-}
+  // console.log("rendering: ", props);
+
+  return <img className={`card ${inactive} ${selected}`} src={props.img} alt={props.alt} onClick={handleClick} />;
+});


### PR DESCRIPTION
Refactored to use useReducer function to manage the state of the cards.

useReducer provides a stable dispatcher function which can be passed as a prop to child components.  Since it is stable, it's reference does not change between renders and so useMemo in the child objects does not force a re-render unless the other props change.